### PR TITLE
Edge base evaluations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 .DS_Store
 *.log
 *__pycache__/
+evaluation/results/

--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -1,0 +1,444 @@
+# Project Structure
+
+This repository implements a context-privacy aware edge LLM system with distributed memory. The active runtime is built around two Python FastAPI services:
+
+- `edge-node`: serves user requests, runs local LLM inference, keeps short-term memory on the current edge, and coordinates handover.
+- `memory-layer`: provides global long-term memory through Mem0, Qdrant, and Ollama.
+
+The repository also contains scaffolded workspaces for a dashboard and simulator, plus an evaluation workspace with an initial edge-baseline benchmark.
+
+## Runtime Architecture
+
+```text
+Client
+  |
+  | POST /generate
+  v
+Edge Node
+  |-- local STM store: active session conversation history
+  |-- local LTM cache: short-lived cache of retrieved user memories
+  |-- local model inference: Hugging Face Transformers
+  |
+  | memory search/add
+  v
+Memory Layer
+  |-- Mem0 middleware
+  |-- Qdrant vector store
+  |-- Ollama LLM and embedding models
+```
+
+In the Docker Compose setup, two edge nodes are deployed by default:
+
+- `edge-node-left` on host port `8080`
+- `edge-node-right` on host port `8083`
+
+All edge nodes talk to the shared `memory-layer` on host port `8090`. The memory layer persists vector memory in Qdrant on port `6333` and uses Ollama on port `11434`.
+
+## Top-Level Directories
+
+### `edge-node/`
+
+The edge inference service. This is the main request-serving component.
+
+Important files:
+
+- `app/main.py`: FastAPI application, endpoint definitions, model inference, memory retrieval, STM updates, background memory persistence, and handover orchestration.
+- `app/handover.py`: pure handover decision logic, timestamp parsing, local session registry, topology neighbor estimation, and movement direction helpers.
+- `app/schemas.py`: Pydantic request and response models for generation, memory debugging, handover, and session ending.
+- `app/config.py`: environment-driven edge configuration, model names, memory-layer URL, TTLs, topology, and neighbor URLs.
+- `app/memory_client.py`: HTTP client used by the edge node to call `memory-layer`.
+- `app/prompt_builder.py`: constructs chat messages from system instructions, long-term memories, STM history, and the current user prompt.
+- `app/memory/stm_store.py`: in-process short-term memory store for active sessions.
+- `app/memory/cache.py`: per-user long-term memory cache with TTL.
+- `app/logging_utils.py`: structured event logging helper.
+- `tests/test_handover.py`: unit tests for handover decisions, timestamp normalization, and neighbor estimation.
+- `tests/test_prompt_builder.py`: unit tests for message and prompt construction.
+- `Dockerfile`: production container for the edge service.
+- `Dockerfile.handover-test`: test container used by the Compose `handover-tests` profile.
+- `README.md`: brief service-specific run notes.
+
+The edge node is responsible for:
+
+1. Accepting `POST /generate` requests.
+2. Deciding whether the request belongs to a local, neighbor-recovered, or globally recovered session.
+3. Reading STM from local process memory.
+4. Retrieving LTM from the local cache or global memory layer.
+5. Building the model prompt.
+6. Running local LLM generation through `transformers`.
+7. Appending the user and assistant messages to STM.
+8. Persisting the turn to global memory asynchronously.
+9. Sending or importing handover packages when mobility is detected.
+
+### `memory-layer/`
+
+The global long-term memory service.
+
+Important files:
+
+- `app/main.py`: FastAPI service exposing health, memory search, and memory add endpoints.
+- `app/mem0_service.py`: Mem0 wrapper configured with Qdrant, Ollama LLM, and Ollama embedder.
+- `app/config.py`: memory-layer environment configuration.
+- `requirements.txt`: Python dependencies for FastAPI, Mem0, Qdrant, Ollama, and Pydantic.
+- `Dockerfile`: production container for the memory service.
+- `src/index.ts` and `tsconfig.json`: TypeScript workspace scaffold; not part of the active Python runtime.
+
+The memory layer is responsible for:
+
+1. Receiving normalized memory add/search requests from edge nodes.
+2. Storing user-specific memories through Mem0.
+3. Searching relevant memories by `userId` and query text.
+4. Using Qdrant as the vector database.
+5. Using Ollama for Mem0 LLM and embedding operations.
+
+### `dashboard/`
+
+A Vite/React scaffold for visualization. The current `src/App.tsx` renders a placeholder `Dashboard` view, and `src/lib/api.ts` is available for API integration.
+
+### `simulator/`
+
+A TypeScript workspace intended for simulation of latency, mobility, and failure scenarios. The current `index.ts` is empty, so this is scaffolded rather than implemented.
+
+### `evaluation/`
+
+A TypeScript workspace for benchmark scripts and metric collection.
+
+Current implemented scenario:
+
+- `edge-baseline`: sends `/generate` traffic to a single configured edge endpoint and reports request latency, service-reported TTFT, service-reported total time, throughput, memory source counts, handover mode counts, and errors.
+- `edge-baseline` also reports `inferenceMs` and `inferenceExcludedMs`. The second value subtracts local model generation time from service total time, which helps isolate edge-system overhead from slow laptop CPU inference.
+- `edge-baseline` labels the first request per user as `cold` and later requests from the same user as `hot`, so the result summary includes mean hot-request latency and mean hot-request inference-excluded latency.
+- `edge-baseline-matrix`: runs `edge-baseline` against one edge across multiple user-count and concurrency combinations, then saves all outputs under `evaluation/results`.
+
+Run the default single-edge baseline with:
+
+```bash
+pnpm --filter evaluation scenario:edge-baseline
+```
+
+Useful options:
+
+```bash
+pnpm --filter evaluation scenario:edge-baseline -- \
+  --requests 30 \
+  --concurrency 3 \
+  --warmup 3 \
+  --max-new-tokens 8 \
+  --endpoints http://localhost:8080
+```
+
+The evaluator also supports `--artificial-rtt-ms`. This is currently optional for edge tests, but it will be reused for the planned single-cloud baseline.
+
+Run the default laptop-safe matrix with:
+
+```bash
+pnpm --filter evaluation scenario:edge-baseline-matrix
+```
+
+Default matrix:
+
+- users: `1`, `2`, `3`
+- concurrency modes: `serial`, `concurrent`
+- requests per user: `3`, where request `0` is cold and requests `1..n` are hot
+- concurrent mode cap: `2`
+
+This is intentionally a laptop-scale profile. The local machine has much less memory and no edge-grade accelerator, so it should not use the same concurrent-user counts as a real edge server.
+
+Why these local user counts were chosen:
+
+- `1` user measures the minimum baseline with no meaningful contention.
+- `2` users measures light concurrent pressure on one edge while preserving per-user request order.
+- `3` users adds more local contention on one edge without mixing in topology or handover effects.
+- `5` users was tested as an upper local stress point, but it produced partial or complete failures on this laptop because local CPU inference and local Mem0/Ollama memory retrieval dominated the result. It is therefore excluded from the default matrix.
+- Concurrent mode is capped at `2` because the local machine has about `11.4 GB` available RAM and no edge-grade GPU. Higher local concurrency mostly measures laptop resource exhaustion rather than realistic edge-system behavior.
+
+For a real edge server, the evaluation target would be larger. A modest production edge node may have `64-256 GB` RAM plus an accelerator, while stronger rugged/near-edge servers may have more. Those larger scenarios should be represented later through a cloud/edge simulation profile or a dedicated server run, not by overloading the local laptop.
+
+This produces a timestamped directory under `evaluation/results` with:
+
+- `config.json`: the matrix configuration.
+- one JSON file per parameter combination.
+- `summary.json`: compact cross-run comparison.
+
+Example custom matrix:
+
+```bash
+pnpm --filter evaluation scenario:edge-baseline-matrix -- \
+  --users 1,2,3 \
+  --concurrency-modes serial,concurrent \
+  --requests-per-user 3 \
+  --max-concurrent-users 2 \
+  --max-new-tokens 8
+```
+
+## Docker Compose Services
+
+`docker-compose.yml` wires the local stack together:
+
+- `qdrant`: vector database used by Mem0.
+- `ollama`: local model server for memory-layer LLM and embedding operations.
+- `ollama-init`: pulls the configured Ollama LLM and embedding models before the memory layer starts.
+- `memory-layer`: global memory API.
+- `edge-node-left`: first edge server.
+- `edge-node-right`: right edge server.
+- `handover-tests`: optional test profile for edge handover unit tests.
+
+Run the full stack with:
+
+```bash
+docker compose up --build
+```
+
+Run the handover tests through Compose with:
+
+```bash
+docker compose --profile test up --build handover-tests
+```
+
+## Edge Node API Surface
+
+### `GET /health`
+
+Returns service health, edge identity, model name, LTM cache stats, local session registry stats, STM stats, topology, and neighbor configuration.
+
+### `POST /generate`
+
+Main inference endpoint. Request fields are defined by `GenerateRequest`:
+
+- `userId`: user identifier.
+- `sessionId`: optional existing session identifier. A new UUID is created if omitted.
+- `lastMessageTimestamp`: optional client timestamp used for handover classification.
+- `clientDirection`: optional `left` or `right` mobility hint.
+- `clientSpeed`: optional mobility speed used for proactive handover thresholding.
+- `prompt`: user prompt.
+- `maxNewTokens`: optional generation token limit.
+
+The response includes generated output and metrics such as TTFT, total latency, memory source, edge ID, handover decision, neighbor recovery status, proactive handover status, and STM turn count.
+
+### Memory Debug Endpoints
+
+- `POST /memory/search`: searches long-term memory through the memory layer.
+- `POST /memory/add`: manually adds a user/assistant turn to long-term memory.
+- `POST /memory/cache/invalidate`: clears a user's edge-local LTM cache entry.
+
+### Handover Endpoints
+
+- `POST /handover/decision`: returns the handover classification for a request.
+- `POST /handover/package`: imports STM and cached LTM from another edge.
+- `POST /handover/export`: exports a session package for reactive neighbor recovery.
+
+### Session Endpoint
+
+- `POST /session/end`: removes a session from local STM.
+
+## Memory Model
+
+### Short-Term Memory
+
+Short-term memory is local to each edge-node process and lives in `STMStore`.
+
+Properties:
+
+- Keyed by `sessionId`.
+- Guarded by `userId` to reduce cross-user leakage risk.
+- Stores ordered user and assistant messages.
+- Exportable and importable for handover.
+- Expires after `SESSION_TTL_SECONDS` / `STM_TTL_SECONDS`.
+- Expired sessions are flushed to the memory layer by a background loop.
+
+### Long-Term Memory
+
+Long-term memory is global and user-specific.
+
+Properties:
+
+- Stored by Mem0.
+- Persisted in Qdrant.
+- Queried by the edge node before inference.
+- Cached per user on the edge node by `LTMCache`.
+- Cache TTL defaults to `300` seconds.
+- Existing user cache entries are refreshed when that user continues an active local session, so the edge does not drop LTM cache while the session is still active.
+- New turns are persisted asynchronously after generation.
+
+Important client behavior:
+
+- To benefit from STM and refreshed LTM cache, a client must reuse the returned `sessionId` on later `/generate` requests.
+- Requests without `sessionId` are treated as new sessions, so they may trigger cold LTM lookups for new users.
+
+## Handover Model
+
+Handover is timestamp-based and implemented in `edge-node/app/handover.py` plus orchestration in `edge-node/app/main.py`.
+
+The system classifies requests into three modes:
+
+- `local_session`: the current edge already has the session, or there is not enough handover signal.
+- `neighbor_recovery`: the session is missing locally, but the last message is recent enough to try fetching STM from the previous neighboring edge.
+- `global_recovery`: the session is missing locally and stale, so the edge falls back to global memory rather than neighbor STM recovery.
+
+The freshness boundary is controlled by:
+
+```text
+HANDOVER_FRESHNESS_THRESHOLD_SECONDS
+```
+
+This is currently tied to `SESSION_TTL_SECONDS`.
+
+### Reactive Neighbor Recovery
+
+When a request arrives at an edge without local STM but with a recent timestamp:
+
+1. The edge classifies the request as `neighbor_recovery`.
+2. It estimates the source edge as the opposite of `clientDirection`.
+3. It calls the source edge's `POST /handover/export`.
+4. If the source has the STM session, the current edge imports it through the handover package.
+5. Generation continues with recovered STM.
+
+### Proactive Handover
+
+After successful generation, if the client provides direction and speed:
+
+1. The edge estimates the target neighbor from `clientDirection`.
+2. It checks `MIN_HANDOVER_PREFETCH_SPEED`.
+3. If eligible, it builds a handover package with STM and retrieved LTM.
+4. It sends the package to the target edge in a background task.
+
+## Prompt Construction
+
+Prompt construction happens in `edge-node/app/prompt_builder.py`.
+
+The model input includes:
+
+1. A base system message.
+2. A system memory block containing relevant long-term memories.
+3. Short-term session history from STM.
+4. The current user prompt.
+
+If the tokenizer has a chat template, `tokenizer.apply_chat_template` is used. Otherwise the service falls back to a plain text prompt format.
+
+## Important Environment Variables
+
+### Edge Node
+
+- `EDGE_NODE_ID`: identity of the current edge.
+- `MODEL_NAME`: Hugging Face model used for edge inference.
+- `MEMORY_LAYER_URL`: URL of the memory-layer service.
+- `MEMORY_SEARCH_LIMIT`: number of memories retrieved per request.
+- `LTM_CACHE_TTL_SECONDS`: edge-local LTM cache TTL.
+- `SESSION_TTL_SECONDS`: STM and handover freshness TTL.
+- `HANDOVER_FRESHNESS_THRESHOLD_SECONDS`: fallback source for session TTL.
+- `EDGE_TOPOLOGY`: comma-separated ordered edge IDs.
+- `EDGE_NEIGHBOR_LEFT_URL`: URL for the left neighbor.
+- `EDGE_NEIGHBOR_RIGHT_URL`: URL for the right neighbor.
+- `MIN_HANDOVER_PREFETCH_SPEED`: minimum speed required for proactive handover.
+
+### Memory Layer
+
+- `MEMORY_PORT`: memory service port.
+- `QDRANT_HOST`: Qdrant host.
+- `QDRANT_PORT`: Qdrant port.
+- `QDRANT_COLLECTION`: Qdrant collection name.
+- `OLLAMA_BASE_URL`: Ollama API URL.
+- `OLLAMA_LLM_MODEL`: Ollama model used by Mem0.
+- `OLLAMA_EMBED_MODEL`: Ollama embedding model used by Mem0.
+
+## Testing
+
+Current tests are focused on pure edge-node logic:
+
+- Handover mode selection.
+- Handover package export/import, target validation, and user/session mismatch rejection.
+- STM creation, user isolation, export/import, expiry detection, and cleanup.
+- LTM cache hit, expiry, invalidation, and clear behavior.
+- Edge-to-memory client payloads and Mem0-style result parsing.
+- Timestamp parsing and browser epoch millisecond normalization.
+- Linear topology neighbor estimation.
+- Prompt/message construction.
+
+Run locally from `edge-node/` with:
+
+```bash
+python -m unittest discover -s tests
+```
+
+Or use the Docker Compose test profile:
+
+```bash
+docker compose --profile test up --build handover-tests
+```
+
+## Evaluation Plan
+
+The evaluation track is being built around five main questions:
+
+1. How fast is the multi-edge system without mobility or congestion?
+2. How does latency degrade under congestion?
+3. How well does handover preserve STM when users move between edges?
+4. How much does the memory layer and LTM cache affect latency?
+5. How does the edge design compare to a single centralized cloud-style LLM service?
+
+The first implemented scenario is `edge-baseline`. It measures the single-edge baseline before adding congestion, mobility, or topology effects, which gives later scenarios a stable comparison point. The `edge-baseline-matrix` scenario repeats that baseline across user-count and concurrency combinations, and separates cold first requests from hot cache-eligible follow-up requests.
+
+Local evaluation uses scaled-down user counts because this development machine is not representative of a production edge server. For local runs, prefer `1`, `2`, and `3` logical users with concurrent mode capped at `2`. Real edge-server scenarios can be modeled later with larger synthetic counts and artificial/cloud baselines rather than running all inference locally.
+
+Because local inference can dominate latency on a laptop, `/generate` returns component timings:
+
+- `handoverDecisionMs`
+- `neighborRecoveryMs`
+- `stmReadMs`
+- `memoryRetrievalMs`
+- `promptBuildMs`
+- `tokenizationMs`
+- `inferenceMs`
+- `inferenceTtftMs`
+- `postInferenceMs`
+- `inferenceExcludedMs`
+
+Future congestion tests should compare both total latency and `inferenceExcludedMs`. Total latency captures user-visible delay, while `inferenceExcludedMs` better reflects queueing, memory lookup, handover, and edge coordination overhead.
+
+Planned cloud baseline:
+
+- Add a `cloud-node` service later using the same edge-node image and inference path, but configured as a centralized endpoint with no neighbors.
+- Route all synthetic users to that one endpoint.
+- Add configurable artificial RTT in the evaluator using `--artificial-rtt-ms`.
+- Use the same prompt, output-token cap, request count, and concurrency settings as the edge scenarios.
+
+Why configurable cloud RTT is needed:
+
+- Public LLM latency benchmarks show normal TTFT often in the hundreds of milliseconds, with large variation by provider and model.
+- Under load, queueing can push tail latency into multi-second territory.
+- Because provider latency varies by region, prompt size, model, queue depth, and streaming behavior, the evaluator should not hard-code one cloud number.
+
+Useful cloud-delay presets for later experiments:
+
+- `--artificial-rtt-ms 80`: nearby regional cloud.
+- `--artificial-rtt-ms 150`: common cross-region or moderately distant cloud.
+- `--artificial-rtt-ms 300`: distant cloud or congested network path.
+
+Research references used for these assumptions:
+
+- DeployBase, "LLM API Latency Comparison: Time-to-First-Token Analysis", reports provider TTFT p50/p95 ranges across major LLM APIs.
+- LLM Benchmarks, OpenAI provider benchmark page, reports average OpenAI time to first token and token throughput measurements.
+- SitePoint, "Ollama vs vLLM: Performance Benchmark 2026", shows queueing-driven latency growth under concurrent load.
+- Together AI, "Cache-aware prefill-decode disaggregation", discusses TTFT rising sharply as QPS approaches saturation.
+
+## Current Implementation Status
+
+Implemented:
+
+- Edge inference API.
+- Long-term memory integration through a memory-layer service.
+- Edge-local STM.
+- Edge-local LTM cache.
+- Timestamp-based handover decision logic.
+- Reactive neighbor STM recovery.
+- Proactive handover prefetch.
+- Background persistence of generated turns.
+- Unit tests for handover and prompt construction.
+- Three-edge Docker Compose topology: left, middle, and right.
+- Evaluation CLI with the initial `edge-baseline` scenario.
+
+Scaffolded or minimal:
+
+- Dashboard UI.
+- Simulator.
+- Congestion, handover, memory-cache, failure, and cloud-baseline evaluation scenarios.
+- TypeScript entrypoints in `memory-layer/src`.

--- a/edge-node/app/handover_package.py
+++ b/edge-node/app/handover_package.py
@@ -1,0 +1,97 @@
+from fastapi import HTTPException
+
+from app.memory.cache import LTMCache
+from app.memory.stm_store import STMStore
+from app.schemas import HandoverExportRequest, HandoverPackageRequest
+
+
+def build_handover_package(
+    *,
+    edge_node_id: str,
+    stm_store: STMStore,
+    user_id: str,
+    session_id: str,
+    target_edge_id: str,
+    transfer_reason: str,
+    client_direction: str | None,
+    client_speed: float | None,
+    memories: list[str],
+) -> dict:
+    return {
+        "userId": user_id,
+        "sessionId": session_id,
+        "sourceEdgeId": edge_node_id,
+        "targetEdgeId": target_edge_id,
+        "transferReason": transfer_reason,
+        "clientDirection": client_direction,
+        "clientSpeed": client_speed,
+        "stm": stm_store.export_session(session_id),
+        "ltm": memories,
+    }
+
+
+def import_handover_package(
+    *,
+    edge_node_id: str,
+    stm_store: STMStore,
+    ltm_cache: LTMCache,
+    local_session_registry,
+    package: HandoverPackageRequest,
+) -> dict:
+    if package.targetEdgeId != edge_node_id:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Package target is {package.targetEdgeId}, not {edge_node_id}",
+        )
+
+    if package.stm is not None:
+        stm_user_id = package.stm.get("userId")
+        stm_session_id = package.stm.get("sessionId")
+        if stm_user_id != package.userId or stm_session_id != package.sessionId:
+            raise HTTPException(
+                status_code=400,
+                detail="STM package userId/sessionId does not match handover package",
+            )
+        stm_store.import_session(package.stm)
+    else:
+        stm_store.get_or_create(
+            session_id=package.sessionId,
+            user_id=package.userId,
+        )
+
+    ltm_cache.set(package.userId, package.ltm)
+    local_session_registry.touch(
+        user_id=package.userId,
+        session_id=package.sessionId,
+        edge_id=edge_node_id,
+    )
+
+    return {
+        "stmImported": package.stm is not None,
+        "ltmCount": len(package.ltm),
+    }
+
+
+def export_handover_package(
+    *,
+    edge_node_id: str,
+    stm_store: STMStore,
+    ltm_cache: LTMCache,
+    request: HandoverExportRequest,
+) -> dict:
+    session = stm_store.export_session(request.sessionId)
+    if session is None or session["userId"] != request.userId:
+        raise HTTPException(status_code=404, detail="Session not found on this edge")
+
+    memories = ltm_cache.get(request.userId) or []
+    return build_handover_package(
+        edge_node_id=edge_node_id,
+        stm_store=stm_store,
+        user_id=request.userId,
+        session_id=request.sessionId,
+        target_edge_id=request.targetEdgeId,
+        transfer_reason="reactive_neighbor_recovery",
+        client_direction=None,
+        client_speed=None,
+        memories=memories,
+    )

--- a/edge-node/app/main.py
+++ b/edge-node/app/main.py
@@ -30,6 +30,15 @@ from app.handover import (
     opposite_direction,
     parse_timestamp_seconds,
 )
+from app.handover_package import (
+    build_handover_package as build_handover_package_payload,
+)
+from app.handover_package import (
+    export_handover_package as export_handover_package_payload,
+)
+from app.handover_package import (
+    import_handover_package as import_handover_package_payload,
+)
 from app.logging_utils import log_event
 from app.memory.cache import LTMCache
 from app.memory.stm_store import STMStore
@@ -103,6 +112,11 @@ local_session_registry = LocalSessionRegistry(
 )
 
 
+def elapsed_ms(start: float, end: float | None = None) -> float:
+    finish = end if end is not None else time.perf_counter()
+    return round((finish - start) * 1000, 2)
+
+
 def classify_handover(
     *,
     user_id: str,
@@ -167,52 +181,27 @@ def build_handover_package(
     client_speed: float | None,
     memories: List[str],
 ) -> dict:
-    return {
-        "userId": user_id,
-        "sessionId": session_id,
-        "sourceEdgeId": EDGE_NODE_ID,
-        "targetEdgeId": target_edge_id,
-        "transferReason": transfer_reason,
-        "clientDirection": client_direction,
-        "clientSpeed": client_speed,
-        "stm": stm_store.export_session(session_id),
-        "ltm": memories,
-    }
+    return build_handover_package_payload(
+        edge_node_id=EDGE_NODE_ID,
+        stm_store=stm_store,
+        user_id=user_id,
+        session_id=session_id,
+        target_edge_id=target_edge_id,
+        transfer_reason=transfer_reason,
+        client_direction=client_direction,
+        client_speed=client_speed,
+        memories=memories,
+    )
 
 
 def import_handover_package(package: HandoverPackageRequest) -> dict:
-    if package.targetEdgeId != EDGE_NODE_ID:
-        raise HTTPException(
-            status_code=409,
-            detail=f"Package target is {package.targetEdgeId}, not {EDGE_NODE_ID}",
-        )
-
-    if package.stm is not None:
-        stm_user_id = package.stm.get("userId")
-        stm_session_id = package.stm.get("sessionId")
-        if stm_user_id != package.userId or stm_session_id != package.sessionId:
-            raise HTTPException(
-                status_code=400,
-                detail="STM package userId/sessionId does not match handover package",
-            )
-        stm_store.import_session(package.stm)
-    else:
-        stm_store.get_or_create(
-            session_id=package.sessionId,
-            user_id=package.userId,
-        )
-
-    ltm_cache.set(package.userId, package.ltm)
-    local_session_registry.touch(
-        user_id=package.userId,
-        session_id=package.sessionId,
-        edge_id=EDGE_NODE_ID,
+    return import_handover_package_payload(
+        edge_node_id=EDGE_NODE_ID,
+        stm_store=stm_store,
+        ltm_cache=ltm_cache,
+        local_session_registry=local_session_registry,
+        package=package,
     )
-
-    return {
-        "stmImported": package.stm is not None,
-        "ltmCount": len(package.ltm),
-    }
 
 
 async def send_handover_package(
@@ -468,19 +457,11 @@ def receive_handover_package(req: HandoverPackageRequest):
 
 @app.post("/handover/export")
 def export_handover_package(req: HandoverExportRequest):
-    session = stm_store.export_session(req.sessionId)
-    if session is None or session["userId"] != req.userId:
-        raise HTTPException(status_code=404, detail="Session not found on this edge")
-
-    memories = ltm_cache.get(req.userId) or []
-    package = build_handover_package(
-        user_id=req.userId,
-        session_id=req.sessionId,
-        target_edge_id=req.targetEdgeId,
-        transfer_reason="reactive_neighbor_recovery",
-        client_direction=None,
-        client_speed=None,
-        memories=memories,
+    package = export_handover_package_payload(
+        edge_node_id=EDGE_NODE_ID,
+        stm_store=stm_store,
+        ltm_cache=ltm_cache,
+        request=req,
     )
 
     log_event(
@@ -491,7 +472,7 @@ def export_handover_package(req: HandoverExportRequest):
             "userId": req.userId,
             "sessionId": req.sessionId,
             "stmIncluded": package["stm"] is not None,
-            "ltmCount": len(memories),
+            "ltmCount": len(package["ltm"]),
         },
     )
 
@@ -506,13 +487,16 @@ async def generate(req: GenerateRequest, background_tasks: BackgroundTasks):
     request_id = str(uuid.uuid4())
     session_id = req.sessionId or str(uuid.uuid4())
     started = time.perf_counter()
+    timings: dict[str, float | None] = {}
 
     try:
+        handover_decision_started = time.perf_counter()
         handover_decision = classify_handover(
             user_id=req.userId,
             session_id=req.sessionId,
             last_message_timestamp=req.lastMessageTimestamp,
         )
+        timings["handoverDecisionMs"] = elapsed_ms(handover_decision_started)
 
         log_event(
             "handover_decision",
@@ -524,12 +508,15 @@ async def generate(req: GenerateRequest, background_tasks: BackgroundTasks):
         )
 
         neighbor_recovery = {"attempted": False}
+        timings["neighborRecoveryMs"] = 0
         if handover_decision.mode == "neighbor_recovery" and req.sessionId:
+            neighbor_recovery_started = time.perf_counter()
             neighbor_recovery = await recover_from_neighbor(
                 user_id=req.userId,
                 session_id=req.sessionId,
                 client_direction=req.clientDirection,
             )
+            timings["neighborRecoveryMs"] = elapsed_ms(neighbor_recovery_started)
             log_event(
                 "neighbor_recovery_completed",
                 {
@@ -542,12 +529,17 @@ async def generate(req: GenerateRequest, background_tasks: BackgroundTasks):
             )
 
             if neighbor_recovery.get("recovered"):
+                handover_reclassify_started = time.perf_counter()
                 handover_decision = classify_handover(
                     user_id=req.userId,
                     session_id=req.sessionId,
                     last_message_timestamp=req.lastMessageTimestamp,
                 )
+                timings["handoverReclassifyMs"] = elapsed_ms(
+                    handover_reclassify_started
+                )
 
+        stm_started = time.perf_counter()
         try:
             stm_store.get_or_create(session_id=session_id, user_id=req.userId)
         except ValueError as e:
@@ -558,15 +550,20 @@ async def generate(req: GenerateRequest, background_tasks: BackgroundTasks):
             session_id=session_id,
             edge_id=EDGE_NODE_ID,
         )
+        ltm_cache.touch(req.userId)
 
         stm_history = stm_store.get_history(session_id)
+        timings["stmReadMs"] = elapsed_ms(stm_started)
 
+        memory_started = time.perf_counter()
         memories, memory_source = await retrieve_memories(
             user_id=req.userId,
             query=req.prompt,
             limit=MEMORY_SEARCH_LIMIT,
         )
+        timings["memoryRetrievalMs"] = elapsed_ms(memory_started)
 
+        prompt_started = time.perf_counter()
         messages = build_messages(
             user_prompt=req.prompt,
             memories=memories,
@@ -585,8 +582,11 @@ async def generate(req: GenerateRequest, background_tasks: BackgroundTasks):
                 memories=memories,
                 history=stm_history,
             )
+        timings["promptBuildMs"] = elapsed_ms(prompt_started)
 
+        tokenization_started = time.perf_counter()
         inputs = tokenizer(model_input, return_tensors="pt")
+        timings["tokenizationMs"] = elapsed_ms(tokenization_started)
         streamer = TextIteratorStreamer(
             tokenizer,
             skip_prompt=True,
@@ -603,6 +603,7 @@ async def generate(req: GenerateRequest, background_tasks: BackgroundTasks):
             "pad_token_id": tokenizer.eos_token_id,
         }
 
+        inference_started = time.perf_counter()
         thread = Thread(target=model.generate, kwargs=generation_kwargs)
         thread.start()
 
@@ -616,14 +617,19 @@ async def generate(req: GenerateRequest, background_tasks: BackgroundTasks):
 
         thread.join()
 
-        finished = time.perf_counter()
+        inference_finished = time.perf_counter()
         output = "".join(chunks).strip()
+        timings["inferenceMs"] = elapsed_ms(inference_started, inference_finished)
 
         ttft_ms = None
         if first_token_time is not None:
             ttft_ms = round((first_token_time - started) * 1000, 2)
+            timings["inferenceTtftMs"] = elapsed_ms(
+                inference_started,
+                first_token_time,
+            )
 
-        total_ms = round((finished - started) * 1000, 2)
+        postprocess_started = time.perf_counter()
 
         stm_store.append(session_id, "user", req.prompt)
         stm_store.append(session_id, "assistant", output)
@@ -675,6 +681,7 @@ async def generate(req: GenerateRequest, background_tasks: BackgroundTasks):
                     "stmIncluded": package["stm"] is not None,
                     "ltmCount": len(memories),
                 }
+        timings["postInferenceMs"] = elapsed_ms(postprocess_started)
 
         background_tasks.add_task(
             persist_memory_background,
@@ -682,6 +689,14 @@ async def generate(req: GenerateRequest, background_tasks: BackgroundTasks):
             req.prompt,
             output,
         )
+
+        finished = time.perf_counter()
+        total_ms = elapsed_ms(started, finished)
+        inference_ms = timings.get("inferenceMs")
+        inference_excluded_ms = None
+        if isinstance(inference_ms, (int, float)):
+            inference_excluded_ms = round(total_ms - inference_ms, 2)
+        timings["inferenceExcludedMs"] = inference_excluded_ms
 
         log_event(
             "generate_completed",
@@ -703,6 +718,7 @@ async def generate(req: GenerateRequest, background_tasks: BackgroundTasks):
                 "proactiveHandover": proactive_handover,
                 "ttftMs": ttft_ms,
                 "totalMs": total_ms,
+                "timings": timings,
                 "status": "success",
             },
         )
@@ -715,6 +731,9 @@ async def generate(req: GenerateRequest, background_tasks: BackgroundTasks):
             metrics={
                 "ttftMs": ttft_ms,
                 "totalMs": total_ms,
+                "inferenceMs": timings["inferenceMs"],
+                "inferenceExcludedMs": timings["inferenceExcludedMs"],
+                "timings": timings,
                 "modelName": MODEL_NAME,
                 "memoryCount": len(memories),
                 "memorySource": memory_source,

--- a/edge-node/app/memory/cache.py
+++ b/edge-node/app/memory/cache.py
@@ -35,6 +35,19 @@ class LTMCache:
             expires_at=now + self.ttl_seconds,
         )
 
+    def touch(self, user_id: str) -> bool:
+        entry = self._store.get(user_id)
+        if entry is None:
+            return False
+
+        now = time.time()
+        if now >= entry.expires_at:
+            self._store.pop(user_id, None)
+            return False
+
+        entry.expires_at = now + self.ttl_seconds
+        return True
+
     def invalidate(self, user_id: str) -> None:
         self._store.pop(user_id, None)
 

--- a/edge-node/tests/test_handover_package.py
+++ b/edge-node/tests/test_handover_package.py
@@ -1,0 +1,198 @@
+import pathlib
+import sys
+import unittest
+
+from fastapi import HTTPException
+
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from app.handover import LocalSessionRegistry  # noqa: E402
+from app.handover_package import (  # noqa: E402
+    build_handover_package,
+    export_handover_package,
+    import_handover_package,
+)
+from app.memory.cache import LTMCache  # noqa: E402
+from app.memory.stm_store import STMStore  # noqa: E402
+from app.schemas import HandoverExportRequest, HandoverPackageRequest  # noqa: E402
+
+
+class HandoverPackageTests(unittest.TestCase):
+    def test_build_package_includes_stm_and_ltm(self) -> None:
+        stm_store = STMStore()
+        stm_store.get_or_create(session_id="s1", user_id="u1")
+        stm_store.append("s1", "user", "before moving")
+
+        package = build_handover_package(
+            edge_node_id="edge-left",
+            stm_store=stm_store,
+            user_id="u1",
+            session_id="s1",
+            target_edge_id="edge-right",
+            transfer_reason="predictive_client_mobility",
+            client_direction="right",
+            client_speed=3.5,
+            memories=["likes concise answers"],
+        )
+
+        self.assertEqual(package["sourceEdgeId"], "edge-left")
+        self.assertEqual(package["targetEdgeId"], "edge-right")
+        self.assertEqual(package["stm"]["sessionId"], "s1")
+        self.assertEqual(package["stm"]["userId"], "u1")
+        self.assertEqual(package["stm"]["messages"][0]["content"], "before moving")
+        self.assertEqual(package["ltm"], ["likes concise answers"])
+
+    def test_export_package_rejects_wrong_user_for_session(self) -> None:
+        stm_store = STMStore()
+        ltm_cache = LTMCache()
+        stm_store.get_or_create(session_id="s1", user_id="owner")
+
+        with self.assertRaises(HTTPException) as raised:
+            export_handover_package(
+                edge_node_id="edge-left",
+                stm_store=stm_store,
+                ltm_cache=ltm_cache,
+                request=HandoverExportRequest(
+                    userId="attacker",
+                    sessionId="s1",
+                    targetEdgeId="edge-right",
+                ),
+            )
+
+        self.assertEqual(raised.exception.status_code, 404)
+
+    def test_export_package_includes_cached_ltm_for_user(self) -> None:
+        stm_store = STMStore()
+        ltm_cache = LTMCache()
+        stm_store.get_or_create(session_id="s1", user_id="u1")
+        stm_store.append("s1", "assistant", "context")
+        ltm_cache.set("u1", ["memory one", "memory two"])
+
+        package = export_handover_package(
+            edge_node_id="edge-left",
+            stm_store=stm_store,
+            ltm_cache=ltm_cache,
+            request=HandoverExportRequest(
+                userId="u1",
+                sessionId="s1",
+                targetEdgeId="edge-right",
+            ),
+        )
+
+        self.assertEqual(package["transferReason"], "reactive_neighbor_recovery")
+        self.assertEqual(package["ltm"], ["memory one", "memory two"])
+        self.assertEqual(package["stm"]["messages"][0]["content"], "context")
+
+    def test_import_package_rejects_wrong_target_edge(self) -> None:
+        with self.assertRaises(HTTPException) as raised:
+            import_handover_package(
+                edge_node_id="edge-right",
+                stm_store=STMStore(),
+                ltm_cache=LTMCache(),
+                local_session_registry=LocalSessionRegistry(ttl_seconds=120),
+                package=HandoverPackageRequest(
+                    userId="u1",
+                    sessionId="s1",
+                    sourceEdgeId="edge-left",
+                    targetEdgeId="edge-other",
+                    transferReason="predictive_client_mobility",
+                    stm=None,
+                    ltm=[],
+                ),
+            )
+
+        self.assertEqual(raised.exception.status_code, 409)
+
+    def test_import_package_rejects_mismatched_stm_identity(self) -> None:
+        with self.assertRaises(HTTPException) as raised:
+            import_handover_package(
+                edge_node_id="edge-right",
+                stm_store=STMStore(),
+                ltm_cache=LTMCache(),
+                local_session_registry=LocalSessionRegistry(ttl_seconds=120),
+                package=HandoverPackageRequest(
+                    userId="u1",
+                    sessionId="s1",
+                    sourceEdgeId="edge-left",
+                    targetEdgeId="edge-right",
+                    transferReason="predictive_client_mobility",
+                    stm={
+                        "userId": "u2",
+                        "sessionId": "s1",
+                        "createdAt": 1000,
+                        "lastActiveAt": 1001,
+                        "messages": [],
+                    },
+                    ltm=[],
+                ),
+            )
+
+        self.assertEqual(raised.exception.status_code, 400)
+
+    def test_import_package_hydrates_stm_ltm_cache_and_local_registry(self) -> None:
+        stm_store = STMStore()
+        ltm_cache = LTMCache()
+        registry = LocalSessionRegistry(ttl_seconds=120)
+
+        result = import_handover_package(
+            edge_node_id="edge-right",
+            stm_store=stm_store,
+            ltm_cache=ltm_cache,
+            local_session_registry=registry,
+            package=HandoverPackageRequest(
+                userId="u1",
+                sessionId="s1",
+                sourceEdgeId="edge-left",
+                targetEdgeId="edge-right",
+                transferReason="predictive_client_mobility",
+                stm={
+                    "userId": "u1",
+                    "sessionId": "s1",
+                    "createdAt": 1000,
+                    "lastActiveAt": 1001,
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": "carry this over",
+                            "timestamp": 1000,
+                        }
+                    ],
+                },
+                ltm=["cached memory"],
+            ),
+        )
+
+        self.assertEqual(result, {"stmImported": True, "ltmCount": 1})
+        self.assertEqual(stm_store.get_history("s1")[0]["content"], "carry this over")
+        self.assertEqual(ltm_cache.get("u1"), ["cached memory"])
+        self.assertTrue(
+            registry.has_fresh_session(user_id="u1", session_id="s1")
+        )
+
+    def test_import_package_without_stm_creates_empty_session(self) -> None:
+        stm_store = STMStore()
+
+        result = import_handover_package(
+            edge_node_id="edge-right",
+            stm_store=stm_store,
+            ltm_cache=LTMCache(),
+            local_session_registry=LocalSessionRegistry(ttl_seconds=120),
+            package=HandoverPackageRequest(
+                userId="u1",
+                sessionId="s1",
+                sourceEdgeId="edge-left",
+                targetEdgeId="edge-right",
+                transferReason="predictive_client_mobility",
+                stm=None,
+                ltm=[],
+            ),
+        )
+
+        self.assertEqual(result, {"stmImported": False, "ltmCount": 0})
+        self.assertEqual(stm_store.get_history("s1"), [])
+        self.assertEqual(stm_store.export_session("s1")["userId"], "u1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/edge-node/tests/test_ltm_cache.py
+++ b/edge-node/tests/test_ltm_cache.py
@@ -1,0 +1,81 @@
+import pathlib
+import sys
+import unittest
+from unittest.mock import patch
+
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from app.memory.cache import LTMCache  # noqa: E402
+
+
+class LTMCacheTests(unittest.TestCase):
+    def test_returns_cached_memories_before_ttl_expires(self) -> None:
+        cache = LTMCache(ttl_seconds=60)
+
+        with patch("app.memory.cache.time.time", return_value=1000):
+            cache.set("u1", ["memory"])
+
+        with patch("app.memory.cache.time.time", return_value=1059):
+            self.assertEqual(cache.get("u1"), ["memory"])
+
+    def test_expires_cached_memories_at_ttl_boundary(self) -> None:
+        cache = LTMCache(ttl_seconds=60)
+
+        with patch("app.memory.cache.time.time", return_value=1000):
+            cache.set("u1", ["memory"])
+
+        with patch("app.memory.cache.time.time", return_value=1060):
+            self.assertIsNone(cache.get("u1"))
+
+        self.assertEqual(cache.stats()["entryCount"], 0)
+
+    def test_invalidate_removes_only_requested_user(self) -> None:
+        cache = LTMCache()
+        cache.set("u1", ["one"])
+        cache.set("u2", ["two"])
+
+        cache.invalidate("u1")
+
+        self.assertIsNone(cache.get("u1"))
+        self.assertEqual(cache.get("u2"), ["two"])
+
+    def test_touch_extends_existing_cache_entry(self) -> None:
+        cache = LTMCache(ttl_seconds=60)
+
+        with patch("app.memory.cache.time.time", return_value=1000):
+            cache.set("u1", ["memory"])
+
+        with patch("app.memory.cache.time.time", return_value=1050):
+            self.assertTrue(cache.touch("u1"))
+
+        with patch("app.memory.cache.time.time", return_value=1109):
+            self.assertEqual(cache.get("u1"), ["memory"])
+
+    def test_touch_returns_false_for_missing_or_expired_entry(self) -> None:
+        cache = LTMCache(ttl_seconds=60)
+
+        self.assertFalse(cache.touch("missing"))
+
+        with patch("app.memory.cache.time.time", return_value=1000):
+            cache.set("u1", ["memory"])
+
+        with patch("app.memory.cache.time.time", return_value=1060):
+            self.assertFalse(cache.touch("u1"))
+
+        self.assertEqual(cache.stats()["entryCount"], 0)
+
+    def test_clear_removes_all_entries(self) -> None:
+        cache = LTMCache()
+        cache.set("u1", ["one"])
+        cache.set("u2", ["two"])
+
+        cache.clear()
+
+        self.assertEqual(cache.stats()["entryCount"], 0)
+        self.assertIsNone(cache.get("u1"))
+        self.assertIsNone(cache.get("u2"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/edge-node/tests/test_memory_client.py
+++ b/edge-node/tests/test_memory_client.py
@@ -1,0 +1,95 @@
+import pathlib
+import sys
+import unittest
+from unittest.mock import patch
+
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from app.memory_client import MemoryClient  # noqa: E402
+
+
+class FakeResponse:
+    def __init__(self, payload: dict) -> None:
+        self.payload = payload
+        self.raise_for_status_called = False
+
+    def raise_for_status(self) -> None:
+        self.raise_for_status_called = True
+
+    def json(self) -> dict:
+        return self.payload
+
+
+class FakeAsyncClient:
+    requests = []
+    next_response = FakeResponse({})
+
+    def __init__(self, timeout: float) -> None:
+        self.timeout = timeout
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    async def post(self, url: str, json: dict) -> FakeResponse:
+        self.requests.append({"url": url, "json": json, "timeout": self.timeout})
+        return self.next_response
+
+
+class MemoryClientTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        FakeAsyncClient.requests = []
+        FakeAsyncClient.next_response = FakeResponse({})
+
+    async def test_search_sends_expected_payload_and_extracts_memory_text(self) -> None:
+        FakeAsyncClient.next_response = FakeResponse(
+            {
+                "results": [
+                    {"memory": "likes short answers"},
+                    {"memory": ""},
+                    {"other": "ignored"},
+                    {"memory": "prefers Python"},
+                ]
+            }
+        )
+
+        with patch("app.memory_client.httpx.AsyncClient", FakeAsyncClient):
+            memories = await MemoryClient().search(user_id="u1", query="prefs", limit=2)
+
+        self.assertEqual(memories, ["likes short answers", "prefers Python"])
+        self.assertEqual(
+            FakeAsyncClient.requests[0]["json"],
+            {"userId": "u1", "query": "prefs", "limit": 2},
+        )
+        self.assertTrue(FakeAsyncClient.next_response.raise_for_status_called)
+
+    async def test_search_tolerates_missing_results_field(self) -> None:
+        FakeAsyncClient.next_response = FakeResponse({"ok": True})
+
+        with patch("app.memory_client.httpx.AsyncClient", FakeAsyncClient):
+            memories = await MemoryClient().search(user_id="u1", query="prefs")
+
+        self.assertEqual(memories, [])
+
+    async def test_add_messages_sends_expected_payload(self) -> None:
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+        FakeAsyncClient.next_response = FakeResponse({"ok": True})
+
+        with patch("app.memory_client.httpx.AsyncClient", FakeAsyncClient):
+            await MemoryClient().add_messages(user_id="u1", messages=messages)
+
+        self.assertEqual(
+            FakeAsyncClient.requests[0]["json"],
+            {"userId": "u1", "messages": messages},
+        )
+        self.assertTrue(FakeAsyncClient.next_response.raise_for_status_called)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/edge-node/tests/test_stm_store.py
+++ b/edge-node/tests/test_stm_store.py
@@ -1,0 +1,79 @@
+import pathlib
+import sys
+import unittest
+
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from app.memory.stm_store import STMStore  # noqa: E402
+
+
+class STMStoreTests(unittest.TestCase):
+    def test_creates_session_and_preserves_message_order(self) -> None:
+        store = STMStore()
+        store.get_or_create(session_id="s1", user_id="u1")
+
+        store.append("s1", "user", "hello")
+        store.append("s1", "assistant", "hi")
+        store.append("s1", "user", "remember this")
+
+        history = store.get_history("s1")
+
+        self.assertEqual(
+            [(message["role"], message["content"]) for message in history],
+            [
+                ("user", "hello"),
+                ("assistant", "hi"),
+                ("user", "remember this"),
+            ],
+        )
+
+    def test_rejects_existing_session_for_different_user(self) -> None:
+        store = STMStore()
+        store.get_or_create(session_id="shared-session", user_id="u1")
+
+        with self.assertRaisesRegex(ValueError, "different user"):
+            store.get_or_create(session_id="shared-session", user_id="u2")
+
+    def test_export_and_import_preserves_session_identity_and_messages(self) -> None:
+        source = STMStore()
+        source.get_or_create(session_id="s1", user_id="u1")
+        source.append("s1", "user", "first")
+        source.append("s1", "assistant", "second")
+
+        exported = source.export_session("s1")
+        self.assertIsNotNone(exported)
+
+        target = STMStore()
+        imported_session_id = target.import_session(exported)
+
+        self.assertEqual(imported_session_id, "s1")
+        self.assertEqual(target.export_session("s1")["userId"], "u1")
+        self.assertEqual(
+            [(message["role"], message["content"]) for message in target.get_history("s1")],
+            [("user", "first"), ("assistant", "second")],
+        )
+
+    def test_expired_sessions_are_reported_without_removing_them(self) -> None:
+        store = STMStore(session_ttl_seconds=0)
+        store.get_or_create(session_id="s1", user_id="u1")
+        store.append("s1", "user", "expired immediately")
+
+        expired = store.get_expired_sessions()
+
+        self.assertEqual(len(expired), 1)
+        self.assertEqual(expired[0]["sessionId"], "s1")
+        self.assertEqual(expired[0]["userId"], "u1")
+        self.assertIsNotNone(store.export_session("s1"))
+
+    def test_end_session_removes_only_existing_session(self) -> None:
+        store = STMStore()
+        store.get_or_create(session_id="s1", user_id="u1")
+
+        self.assertTrue(store.end_session("s1"))
+        self.assertFalse(store.end_session("s1"))
+        self.assertEqual(store.get_history("s1"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/evaluation/package.json
+++ b/evaluation/package.json
@@ -4,11 +4,15 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "node --watch --loader ts-node/esm src/index.ts",
+    "dev": "node --loader ts-node/esm src/index.ts",
+    "watch": "node --watch --loader ts-node/esm src/index.ts",
+    "scenario:edge-baseline": "node --loader ts-node/esm src/index.ts edge-baseline",
+    "scenario:edge-baseline-matrix": "node --loader ts-node/esm src/index.ts edge-baseline-matrix",
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js"
   },
   "devDependencies": {
+    "@types/node": "^20.17.10",
     "ts-node": "^10.9.2",
     "typescript": "^5.6.3"
   }

--- a/evaluation/src/config.ts
+++ b/evaluation/src/config.ts
@@ -1,0 +1,207 @@
+export type EdgeBaselineConfig = {
+  endpoints: string[];
+  requests: number;
+  concurrency: number;
+  warmupRequests: number;
+  maxNewTokens: number;
+  userCount: number;
+  userPrefix: string;
+  prompt: string;
+  requestTimeoutMs: number;
+  artificialRttMs: number;
+};
+
+export type EdgeBaselineMatrixConfig = {
+  base: Omit<EdgeBaselineConfig, "requests" | "concurrency" | "userCount" | "userPrefix"> & {
+    userPrefix: string;
+  };
+  userCounts: number[];
+  concurrencyModes: Array<"serial" | "concurrent">;
+  requestsPerUser: number;
+  maxConcurrentUsers: number;
+  resultsDir: string;
+  runLabel: string;
+};
+
+export function parseEdgeBaselineConfig(argv: string[]): EdgeBaselineConfig {
+  return {
+    endpoints: getStringList(argv, "endpoints", envList("EVAL_EDGE_ENDPOINTS", [
+      "http://localhost:8080",
+    ])),
+    requests: getNumber(argv, "requests", envNumber("EVAL_REQUESTS", 9)),
+    concurrency: getNumber(argv, "concurrency", envNumber("EVAL_CONCURRENCY", 1)),
+    warmupRequests: getNumber(argv, "warmup", envNumber("EVAL_WARMUP_REQUESTS", 0)),
+    maxNewTokens: getNumber(argv, "max-new-tokens", envNumber("EVAL_MAX_NEW_TOKENS", 8)),
+    userCount: getNumber(argv, "users", envNumber("EVAL_USERS", 1)),
+    userPrefix: getString(argv, "user-prefix", process.env.EVAL_USER_PREFIX ?? "eval-user"),
+    prompt: getString(
+      argv,
+      "prompt",
+      process.env.EVAL_PROMPT ?? "Give a concise one sentence answer about edge AI.",
+    ),
+    requestTimeoutMs: getNumber(
+      argv,
+      "timeout-ms",
+      envNumber("EVAL_REQUEST_TIMEOUT_MS", 120_000),
+    ),
+    artificialRttMs: getNumber(argv, "artificial-rtt-ms", envNumber("EVAL_ARTIFICIAL_RTT_MS", 0)),
+  };
+}
+
+export function parseEdgeBaselineMatrixConfig(argv: string[]): EdgeBaselineMatrixConfig {
+  const base = parseEdgeBaselineConfig(withoutArg(argv, "users"));
+  const userCounts = getNumberList(argv, "users", envNumberList("EVAL_USER_COUNTS", [1, 2, 3]));
+  const concurrencyModes = getConcurrencyModes(argv);
+  const requestsPerUser = getNumber(
+      argv,
+      "requests-per-user",
+      envNumber("EVAL_REQUESTS_PER_USER", 3),
+  );
+
+  return {
+    base: {
+      endpoints: base.endpoints,
+      warmupRequests: base.warmupRequests,
+      maxNewTokens: base.maxNewTokens,
+      userPrefix: base.userPrefix,
+      prompt: base.prompt,
+      requestTimeoutMs: base.requestTimeoutMs,
+      artificialRttMs: base.artificialRttMs,
+    },
+    userCounts,
+    concurrencyModes,
+    requestsPerUser,
+    maxConcurrentUsers: getNumber(
+      argv,
+      "max-concurrent-users",
+      envNumber("EVAL_MAX_CONCURRENT_USERS", 2),
+    ),
+    resultsDir: getString(argv, "results-dir", process.env.EVAL_RESULTS_DIR ?? "results"),
+    runLabel: getString(argv, "run-label", process.env.EVAL_RUN_LABEL ?? "edge-baseline-matrix"),
+  };
+}
+
+function envNumber(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") {
+    return fallback;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`${name} must be a finite number`);
+  }
+  return parsed;
+}
+
+function envList(name: string, fallback: string[]): string[] {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") {
+    return fallback;
+  }
+  return raw.split(",").map((value) => value.trim()).filter(Boolean);
+}
+
+function envNumberList(name: string, fallback: number[]): number[] {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") {
+    return fallback;
+  }
+  return parseNumberList(raw, name);
+}
+
+function getString(argv: string[], name: string, fallback: string): string {
+  const value = getArgValue(argv, name);
+  return value ?? fallback;
+}
+
+function getNumber(argv: string[], name: string, fallback: number): number {
+  const value = getArgValue(argv, name);
+  if (value === undefined) {
+    return fallback;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`--${name} must be a finite number`);
+  }
+  return parsed;
+}
+
+function getStringList(argv: string[], name: string, fallback: string[]): string[] {
+  const value = getArgValue(argv, name);
+  if (value === undefined) {
+    return fallback;
+  }
+  return value.split(",").map((item) => item.trim()).filter(Boolean);
+}
+
+function getNumberList(argv: string[], name: string, fallback: number[]): number[] {
+  const value = getArgValue(argv, name);
+  if (value === undefined) {
+    return fallback;
+  }
+  return parseNumberList(value, `--${name}`);
+}
+
+function getConcurrencyModes(argv: string[]): Array<"serial" | "concurrent"> {
+  const value = getArgValue(argv, "concurrency-modes");
+  const rawModes = value?.split(",") ?? ["serial", "concurrent"];
+  const modes = rawModes.map((mode) => mode.trim()).filter(Boolean);
+
+  for (const mode of modes) {
+    if (mode !== "serial" && mode !== "concurrent") {
+      throw new Error("--concurrency-modes can only contain serial and concurrent");
+    }
+  }
+
+  return Array.from(new Set(modes)) as Array<"serial" | "concurrent">;
+}
+
+function parseNumberList(value: string, source: string): number[] {
+  const numbers = value.split(",").map((item) => {
+    const parsed = Number(item.trim());
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      throw new Error(`${source} must be a comma-separated list of positive integers`);
+    }
+    return parsed;
+  });
+
+  if (numbers.length === 0) {
+    throw new Error(`${source} must not be empty`);
+  }
+
+  return numbers;
+}
+
+function getArgValue(argv: string[], name: string): string | undefined {
+  const prefix = `--${name}=`;
+  const inline = argv.find((arg) => arg.startsWith(prefix));
+  if (inline) {
+    return inline.slice(prefix.length);
+  }
+
+  const index = argv.indexOf(`--${name}`);
+  if (index >= 0) {
+    return argv[index + 1];
+  }
+
+  return undefined;
+}
+
+function withoutArg(argv: string[], name: string): string[] {
+  const result: string[] = [];
+  const prefix = `--${name}=`;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === `--${name}`) {
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith(prefix)) {
+      continue;
+    }
+    result.push(arg);
+  }
+
+  return result;
+}

--- a/evaluation/src/http.ts
+++ b/evaluation/src/http.ts
@@ -1,0 +1,151 @@
+import { performance } from "node:perf_hooks";
+import { setTimeout as sleep } from "node:timers/promises";
+
+export type GenerateResponse = {
+  ok: boolean;
+  userId: string;
+  sessionId: string;
+  output: string;
+  metrics?: {
+    ttftMs?: number | null;
+    totalMs?: number;
+    inferenceMs?: number;
+    inferenceExcludedMs?: number | null;
+    timings?: Record<string, number | null>;
+    memoryCount?: number;
+    memorySource?: string;
+    edgeNodeId?: string;
+    handover?: {
+      mode?: string;
+      reason?: string;
+    };
+    [key: string]: unknown;
+  };
+};
+
+export type GenerateCallResult = {
+  endpoint: string;
+  ok: boolean;
+  status: number | null;
+  latencyMs: number;
+  userId: string;
+  requestIndex?: number;
+  userRequestIndex?: number;
+  cachePhase?: "cold" | "hot";
+  sessionId?: string;
+  edgeNodeId?: string;
+  ttftMs?: number | null;
+  serviceTotalMs?: number;
+  inferenceMs?: number;
+  inferenceExcludedMs?: number | null;
+  timings?: Record<string, number | null>;
+  memorySource?: string;
+  handoverMode?: string;
+  error?: string;
+};
+
+export async function healthCheck(endpoint: string, timeoutMs: number): Promise<void> {
+  const response = await fetchWithTimeout(`${endpoint}/health`, {
+    method: "GET",
+    timeoutMs,
+  });
+  if (!response.ok) {
+    throw new Error(`${endpoint}/health returned ${response.status}`);
+  }
+}
+
+export async function generateOnce(params: {
+  endpoint: string;
+  userId: string;
+  prompt: string;
+  maxNewTokens: number;
+  timeoutMs: number;
+  artificialRttMs: number;
+}): Promise<GenerateCallResult> {
+  const started = performance.now();
+
+  try {
+    await sleepHalfRtt(params.artificialRttMs);
+    const response = await fetchWithTimeout(`${params.endpoint}/generate`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        userId: params.userId,
+        prompt: params.prompt,
+        maxNewTokens: params.maxNewTokens,
+      }),
+      timeoutMs: params.timeoutMs,
+    });
+    await sleepHalfRtt(params.artificialRttMs);
+
+    const latencyMs = roundMs(performance.now() - started);
+    const text = await response.text();
+
+    if (!response.ok) {
+      return {
+        endpoint: params.endpoint,
+        ok: false,
+        status: response.status,
+        latencyMs,
+        userId: params.userId,
+        error: text,
+      };
+    }
+
+    const payload = JSON.parse(text) as GenerateResponse;
+    return {
+      endpoint: params.endpoint,
+      ok: payload.ok,
+      status: response.status,
+      latencyMs,
+      userId: payload.userId,
+      sessionId: payload.sessionId,
+      edgeNodeId: payload.metrics?.edgeNodeId,
+      ttftMs: payload.metrics?.ttftMs,
+      serviceTotalMs: payload.metrics?.totalMs,
+      inferenceMs: payload.metrics?.inferenceMs,
+      inferenceExcludedMs: payload.metrics?.inferenceExcludedMs,
+      timings: payload.metrics?.timings,
+      memorySource: payload.metrics?.memorySource,
+      handoverMode: payload.metrics?.handover?.mode,
+    };
+  } catch (error) {
+    return {
+      endpoint: params.endpoint,
+      ok: false,
+      status: null,
+      latencyMs: roundMs(performance.now() - started),
+      userId: params.userId,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit & { timeoutMs: number },
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), init.timeoutMs);
+  try {
+    return await fetch(url, {
+      ...init,
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function sleepHalfRtt(artificialRttMs: number): Promise<void> {
+  if (artificialRttMs <= 0) {
+    return;
+  }
+  await sleep(artificialRttMs / 2);
+}
+
+function roundMs(value: number): number {
+  return Math.round(value * 100) / 100;
+}

--- a/evaluation/src/index.ts
+++ b/evaluation/src/index.ts
@@ -1,0 +1,73 @@
+import { parseEdgeBaselineConfig, parseEdgeBaselineMatrixConfig } from "./config.js";
+import { runEdgeBaseline } from "./scenarios/edgeBaseline.js";
+import { runEdgeBaselineMatrix } from "./scenarios/edgeBaselineMatrix.js";
+
+const args = process.argv.slice(2);
+if (args[0] === "--") {
+  args.shift();
+}
+const [scenario = "edge-baseline", ...scenarioArgs] = args;
+
+try {
+  switch (scenario) {
+    case "edge-baseline": {
+      const config = parseEdgeBaselineConfig(scenarioArgs);
+      const summary = await runEdgeBaseline(config);
+      console.log(JSON.stringify(summary, null, 2));
+      break;
+    }
+    case "edge-baseline-matrix": {
+      const config = parseEdgeBaselineMatrixConfig(scenarioArgs);
+      const summary = await runEdgeBaselineMatrix(config);
+      console.log(JSON.stringify(summary, null, 2));
+      break;
+    }
+    case "help":
+    case "--help":
+    case "-h":
+      printHelp();
+      break;
+    default:
+      throw new Error(`Unknown evaluation scenario: ${scenario}`);
+  }
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}
+
+function printHelp(): void {
+  console.log(`Usage:
+  pnpm --filter evaluation scenario:edge-baseline -- [options]
+  pnpm --filter evaluation scenario:edge-baseline-matrix -- [options]
+  pnpm --filter evaluation dev -- edge-baseline [options]
+  pnpm --filter evaluation start -- edge-baseline [options]
+
+Scenarios:
+  edge-baseline           Measure baseline /generate latency across edge endpoints.
+  edge-baseline-matrix    Run edge-baseline across user-count and concurrency combinations,
+                          saving JSON results under evaluation/results by default.
+
+edge-baseline options:
+  --endpoints             Comma-separated endpoint URLs.
+                          Default: http://localhost:8080
+  --requests              Number of measured requests. Default: 9
+  --users                 Number of logical users to cycle through. Default: 1
+  --concurrency           Concurrent request workers. Default: 1
+  --warmup                Warmup requests before measurement. Default: 0
+  --max-new-tokens        Generation length cap. Default: 8
+  --prompt                Prompt text.
+  --timeout-ms            Per-request timeout. Default: 120000
+  --artificial-rtt-ms     Adds half before and half after each request. Default: 0
+
+edge-baseline-matrix options:
+  --users                 Comma-separated user counts. Default: 1,2,3
+  --concurrency-modes     serial,concurrent, or both. Default: serial,concurrent
+  --requests-per-user     Requests per logical user in each run. Default: 3
+                          The first request is cold; later requests are hot.
+  --max-concurrent-users  Cap for concurrent mode. Default: 2
+  --results-dir           Directory relative to evaluation/. Default: results
+  --run-label             Suffix for the timestamped result directory.
+  Also accepts shared edge-baseline options: --endpoints, --warmup,
+  --max-new-tokens, --prompt, --timeout-ms, --artificial-rtt-ms.
+`);
+}

--- a/evaluation/src/metrics.ts
+++ b/evaluation/src/metrics.ts
@@ -1,0 +1,237 @@
+import type { GenerateCallResult } from "./http.js";
+
+export type NumericSummary = {
+  count: number;
+  min: number | null;
+  max: number | null;
+  mean: number | null;
+  p50: number | null;
+  p95: number | null;
+  p99: number | null;
+};
+
+export type ScenarioSummary = {
+  scenario: string;
+  startedAt: string;
+  finishedAt: string;
+  durationMs: number;
+  requestCount: number;
+  successCount: number;
+  errorCount: number;
+  throughputRps: number;
+  latencyMs: NumericSummary;
+  ttftMs: NumericSummary;
+  serviceTotalMs: NumericSummary;
+  inferenceMs: NumericSummary;
+  inferenceExcludedMs: NumericSummary;
+  coldRequests: PhaseSummary;
+  hotRequests: PhaseSummary;
+  componentTimingsMs: Record<string, NumericSummary>;
+  byEndpoint: Record<string, {
+    requestCount: number;
+    successCount: number;
+    errorCount: number;
+    latencyMs: NumericSummary;
+  }>;
+  memorySources: Record<string, number>;
+  handoverModes: Record<string, number>;
+  errors: Array<{
+    endpoint: string;
+    status: number | null;
+    error: string;
+  }>;
+};
+
+export type PhaseSummary = {
+  requestCount: number;
+  successCount: number;
+  errorCount: number;
+  latencyMs: NumericSummary;
+  serviceTotalMs: NumericSummary;
+  inferenceMs: NumericSummary;
+  inferenceExcludedMs: NumericSummary;
+  memorySources: Record<string, number>;
+};
+
+export function summarizeScenario(params: {
+  scenario: string;
+  startedAt: Date;
+  finishedAt: Date;
+  durationMs: number;
+  results: GenerateCallResult[];
+}): ScenarioSummary {
+  const success = params.results.filter((result) => result.ok);
+  const errors = params.results.filter((result) => !result.ok);
+  const byEndpoint: ScenarioSummary["byEndpoint"] = {};
+
+  for (const result of params.results) {
+    byEndpoint[result.endpoint] ??= {
+      requestCount: 0,
+      successCount: 0,
+      errorCount: 0,
+      latencyMs: summarizeNumbers([]),
+    };
+    byEndpoint[result.endpoint].requestCount += 1;
+    if (result.ok) {
+      byEndpoint[result.endpoint].successCount += 1;
+    } else {
+      byEndpoint[result.endpoint].errorCount += 1;
+    }
+  }
+
+  for (const [endpoint, endpointSummary] of Object.entries(byEndpoint)) {
+    endpointSummary.latencyMs = summarizeNumbers(
+      params.results
+        .filter((result) => result.endpoint === endpoint)
+        .map((result) => result.latencyMs),
+    );
+  }
+
+  return {
+    scenario: params.scenario,
+    startedAt: params.startedAt.toISOString(),
+    finishedAt: params.finishedAt.toISOString(),
+    durationMs: round(params.durationMs),
+    requestCount: params.results.length,
+    successCount: success.length,
+    errorCount: errors.length,
+    throughputRps: round(success.length / (params.durationMs / 1000)),
+    latencyMs: summarizeNumbers(params.results.map((result) => result.latencyMs)),
+    ttftMs: summarizeNumbers(
+      success
+        .map((result) => result.ttftMs)
+        .filter((value): value is number => typeof value === "number"),
+    ),
+    serviceTotalMs: summarizeNumbers(
+      success
+        .map((result) => result.serviceTotalMs)
+        .filter((value): value is number => typeof value === "number"),
+    ),
+    inferenceMs: summarizeNumbers(
+      success
+        .map((result) => result.inferenceMs)
+        .filter((value): value is number => typeof value === "number"),
+    ),
+    inferenceExcludedMs: summarizeNumbers(
+      success
+        .map((result) => result.inferenceExcludedMs)
+        .filter((value): value is number => typeof value === "number"),
+    ),
+    coldRequests: summarizePhase(params.results, "cold"),
+    hotRequests: summarizePhase(params.results, "hot"),
+    componentTimingsMs: summarizeComponentTimings(success),
+    byEndpoint,
+    memorySources: countBy(success.map((result) => result.memorySource ?? "unknown")),
+    handoverModes: countBy(success.map((result) => result.handoverMode ?? "unknown")),
+    errors: errors.slice(0, 10).map((result) => ({
+      endpoint: result.endpoint,
+      status: result.status,
+      error: result.error ?? "unknown error",
+    })),
+  };
+}
+
+function summarizePhase(results: GenerateCallResult[], phase: "cold" | "hot"): PhaseSummary {
+  const phaseResults = results.filter((result) => result.cachePhase === phase);
+  const success = phaseResults.filter((result) => result.ok);
+
+  return {
+    requestCount: phaseResults.length,
+    successCount: success.length,
+    errorCount: phaseResults.length - success.length,
+    latencyMs: summarizeNumbers(phaseResults.map((result) => result.latencyMs)),
+    serviceTotalMs: summarizeNumbers(
+      success
+        .map((result) => result.serviceTotalMs)
+        .filter((value): value is number => typeof value === "number"),
+    ),
+    inferenceMs: summarizeNumbers(
+      success
+        .map((result) => result.inferenceMs)
+        .filter((value): value is number => typeof value === "number"),
+    ),
+    inferenceExcludedMs: summarizeNumbers(
+      success
+        .map((result) => result.inferenceExcludedMs)
+        .filter((value): value is number => typeof value === "number"),
+    ),
+    memorySources: countBy(success.map((result) => result.memorySource ?? "unknown")),
+  };
+}
+
+function summarizeComponentTimings(
+  results: GenerateCallResult[],
+): Record<string, NumericSummary> {
+  const grouped: Record<string, number[]> = {};
+
+  for (const result of results) {
+    if (!result.timings) {
+      continue;
+    }
+
+    for (const [key, value] of Object.entries(result.timings)) {
+      if (typeof value !== "number") {
+        continue;
+      }
+      grouped[key] ??= [];
+      grouped[key].push(value);
+    }
+  }
+
+  return Object.fromEntries(
+    Object.entries(grouped).map(([key, values]) => [key, summarizeNumbers(values)]),
+  );
+}
+
+export function summarizeNumbers(values: number[]): NumericSummary {
+  if (values.length === 0) {
+    return {
+      count: 0,
+      min: null,
+      max: null,
+      mean: null,
+      p50: null,
+      p95: null,
+      p99: null,
+    };
+  }
+
+  const sorted = [...values].sort((a, b) => a - b);
+  const total = sorted.reduce((sum, value) => sum + value, 0);
+
+  return {
+    count: sorted.length,
+    min: round(sorted[0]),
+    max: round(sorted[sorted.length - 1]),
+    mean: round(total / sorted.length),
+    p50: round(percentile(sorted, 0.5)),
+    p95: round(percentile(sorted, 0.95)),
+    p99: round(percentile(sorted, 0.99)),
+  };
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 1) {
+    return sorted[0];
+  }
+  const index = (sorted.length - 1) * p;
+  const lower = Math.floor(index);
+  const upper = Math.ceil(index);
+  if (lower === upper) {
+    return sorted[lower];
+  }
+  const weight = index - lower;
+  return sorted[lower] * (1 - weight) + sorted[upper] * weight;
+}
+
+function countBy(values: string[]): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const value of values) {
+    counts[value] = (counts[value] ?? 0) + 1;
+  }
+  return counts;
+}
+
+function round(value: number): number {
+  return Math.round(value * 100) / 100;
+}

--- a/evaluation/src/results.ts
+++ b/evaluation/src/results.ts
@@ -1,0 +1,14 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+export async function createResultRunDir(resultsDir: string, runLabel: string): Promise<string> {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const safeLabel = runLabel.replace(/[^a-zA-Z0-9._-]/g, "-");
+  const runDir = path.resolve(process.cwd(), resultsDir, `${timestamp}-${safeLabel}`);
+  await mkdir(runDir, { recursive: true });
+  return runDir;
+}
+
+export async function writeJsonFile(filePath: string, data: unknown): Promise<void> {
+  await writeFile(filePath, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+}

--- a/evaluation/src/scenarios/edgeBaseline.ts
+++ b/evaluation/src/scenarios/edgeBaseline.ts
@@ -1,0 +1,97 @@
+import { performance } from "node:perf_hooks";
+
+import type { EdgeBaselineConfig } from "../config.js";
+import { generateOnce, healthCheck, type GenerateCallResult } from "../http.js";
+import { summarizeScenario, type ScenarioSummary } from "../metrics.js";
+
+export async function runEdgeBaseline(config: EdgeBaselineConfig): Promise<ScenarioSummary> {
+  validateConfig(config);
+
+  for (const endpoint of config.endpoints) {
+    await healthCheck(endpoint, config.requestTimeoutMs);
+  }
+
+  for (let index = 0; index < config.warmupRequests; index += 1) {
+    const endpoint = config.endpoints[index % config.endpoints.length];
+    await generateOnce({
+      endpoint,
+      userId: `${config.userPrefix}-warmup-${index}`,
+      prompt: config.prompt,
+      maxNewTokens: config.maxNewTokens,
+      timeoutMs: config.requestTimeoutMs,
+      artificialRttMs: config.artificialRttMs,
+    });
+  }
+
+  const startedAt = new Date();
+  const started = performance.now();
+  const results = await runPool(config);
+  const durationMs = performance.now() - started;
+  const finishedAt = new Date();
+
+  return summarizeScenario({
+    scenario: "edge-baseline",
+    startedAt,
+    finishedAt,
+    durationMs,
+    results,
+  });
+}
+
+async function runPool(config: EdgeBaselineConfig): Promise<GenerateCallResult[]> {
+  const results: GenerateCallResult[] = [];
+  let nextUserIndex = 0;
+  const perUserRequestCount = Math.ceil(config.requests / config.userCount);
+
+  async function worker(): Promise<void> {
+    while (nextUserIndex < config.userCount) {
+      const userIndex = nextUserIndex;
+      nextUserIndex += 1;
+      const endpoint = config.endpoints[userIndex % config.endpoints.length];
+
+      for (let userRequestIndex = 0; userRequestIndex < perUserRequestCount; userRequestIndex += 1) {
+        const requestIndex = userRequestIndex * config.userCount + userIndex;
+        if (requestIndex >= config.requests) {
+          continue;
+        }
+
+        const result = await generateOnce({
+          endpoint,
+          userId: `${config.userPrefix}-${userIndex}`,
+          prompt: config.prompt,
+          maxNewTokens: config.maxNewTokens,
+          timeoutMs: config.requestTimeoutMs,
+          artificialRttMs: config.artificialRttMs,
+        });
+        results[requestIndex] = {
+          ...result,
+          requestIndex,
+          userRequestIndex,
+          cachePhase: userRequestIndex === 0 ? "cold" : "hot",
+        };
+      }
+    }
+  }
+
+  const workerCount = Math.min(config.concurrency, config.userCount);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  return results;
+}
+
+function validateConfig(config: EdgeBaselineConfig): void {
+  if (config.endpoints.length === 0) {
+    throw new Error("edge-baseline requires at least one endpoint");
+  }
+  if (config.requests <= 0) {
+    throw new Error("edge-baseline requires --requests greater than 0");
+  }
+  if (config.concurrency <= 0) {
+    throw new Error("edge-baseline requires --concurrency greater than 0");
+  }
+  if (config.userCount <= 0) {
+    throw new Error("edge-baseline requires --users greater than 0");
+  }
+  if (config.maxNewTokens <= 0) {
+    throw new Error("edge-baseline requires --max-new-tokens greater than 0");
+  }
+}

--- a/evaluation/src/scenarios/edgeBaselineMatrix.ts
+++ b/evaluation/src/scenarios/edgeBaselineMatrix.ts
@@ -1,0 +1,136 @@
+import path from "node:path";
+
+import type { EdgeBaselineConfig, EdgeBaselineMatrixConfig } from "../config.js";
+import { createResultRunDir, writeJsonFile } from "../results.js";
+import { runEdgeBaseline } from "./edgeBaseline.js";
+
+export type MatrixRunSummary = {
+  runName: string;
+  userCount: number;
+  concurrencyMode: "serial" | "concurrent";
+  requests: number;
+  concurrency: number;
+  outputFile: string;
+  successCount: number;
+  errorCount: number;
+  throughputRps: number;
+  latencyMeanMs: number | null;
+  latencyP95Ms: number | null;
+  serviceTotalMeanMs: number | null;
+  inferenceMeanMs: number | null;
+  inferenceExcludedMeanMs: number | null;
+  coldLatencyMeanMs: number | null;
+  hotLatencyMeanMs: number | null;
+  hotInferenceExcludedMeanMs: number | null;
+};
+
+export type MatrixSummary = {
+  scenario: "edge-baseline-matrix";
+  startedAt: string;
+  finishedAt: string;
+  outputDir: string;
+  config: EdgeBaselineMatrixConfig;
+  runs: MatrixRunSummary[];
+};
+
+export async function runEdgeBaselineMatrix(
+  config: EdgeBaselineMatrixConfig,
+): Promise<MatrixSummary> {
+  validateMatrixConfig(config);
+
+  const startedAt = new Date();
+  const outputDir = await createResultRunDir(config.resultsDir, config.runLabel);
+  const runs: MatrixRunSummary[] = [];
+
+  await writeJsonFile(path.join(outputDir, "config.json"), config);
+
+  for (const userCount of config.userCounts) {
+    for (const concurrencyMode of config.concurrencyModes) {
+      const runName = `${userCount}-users-${concurrencyMode}`;
+      const runConfig = buildRunConfig(config, userCount, concurrencyMode);
+
+      console.error(
+        `Running ${runName}: requests=${runConfig.requests}, concurrency=${runConfig.concurrency}`,
+      );
+
+      const summary = await runEdgeBaseline(runConfig);
+      const outputFile = `${runName}.json`;
+      await writeJsonFile(path.join(outputDir, outputFile), {
+        runName,
+        userCount,
+        concurrencyMode,
+        config: runConfig,
+        summary,
+      });
+
+      runs.push({
+        runName,
+        userCount,
+        concurrencyMode,
+        requests: runConfig.requests,
+        concurrency: runConfig.concurrency,
+        outputFile,
+        successCount: summary.successCount,
+        errorCount: summary.errorCount,
+        throughputRps: summary.throughputRps,
+        latencyMeanMs: summary.latencyMs.mean,
+        latencyP95Ms: summary.latencyMs.p95,
+        serviceTotalMeanMs: summary.serviceTotalMs.mean,
+        inferenceMeanMs: summary.inferenceMs.mean,
+        inferenceExcludedMeanMs: summary.inferenceExcludedMs.mean,
+        coldLatencyMeanMs: summary.coldRequests.latencyMs.mean,
+        hotLatencyMeanMs: summary.hotRequests.latencyMs.mean,
+        hotInferenceExcludedMeanMs: summary.hotRequests.inferenceExcludedMs.mean,
+      });
+    }
+  }
+
+  const matrixSummary: MatrixSummary = {
+    scenario: "edge-baseline-matrix",
+    startedAt: startedAt.toISOString(),
+    finishedAt: new Date().toISOString(),
+    outputDir,
+    config,
+    runs,
+  };
+
+  await writeJsonFile(path.join(outputDir, "summary.json"), matrixSummary);
+  return matrixSummary;
+}
+
+function buildRunConfig(
+  config: EdgeBaselineMatrixConfig,
+  userCount: number,
+  concurrencyMode: "serial" | "concurrent",
+): EdgeBaselineConfig {
+  const requests = userCount * config.requestsPerUser;
+  const concurrency = concurrencyMode === "serial"
+    ? 1
+    : Math.min(userCount, config.maxConcurrentUsers);
+
+  return {
+    ...config.base,
+    userPrefix: `${config.base.userPrefix}-${userCount}u-${concurrencyMode}`,
+    userCount,
+    requests,
+    concurrency,
+  };
+}
+
+function validateMatrixConfig(config: EdgeBaselineMatrixConfig): void {
+  if (config.base.endpoints.length !== 1) {
+    throw new Error("edge-baseline-matrix is scoped to a single edge endpoint");
+  }
+  if (config.userCounts.length === 0) {
+    throw new Error("edge-baseline-matrix requires at least one user count");
+  }
+  if (config.concurrencyModes.length === 0) {
+    throw new Error("edge-baseline-matrix requires at least one concurrency mode");
+  }
+  if (config.requestsPerUser <= 0) {
+    throw new Error("edge-baseline-matrix requires --requests-per-user greater than 0");
+  }
+  if (config.maxConcurrentUsers <= 0) {
+    throw new Error("edge-baseline-matrix requires --max-concurrent-users greater than 0");
+  }
+}

--- a/evaluation/tsconfig.json
+++ b/evaluation/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

This PR adds the initial evaluation framework for the edge-node service and narrows the current `edge-baseline` scenario to measure single-edge behavior clearly. The baseline now focuses on request latency, service-side timing, memory/cache behavior, and concurrent request pressure on one edge node before adding multi-edge topology, mobility, or cloud comparison scenarios.

## Changes

- Added a TypeScript evaluation workspace under `evaluation/`.
- Added `edge-baseline` scenario for sending `/generate` traffic to an edge-node endpoint.
- Added `edge-baseline-matrix` for running baseline tests across:
  - logical user counts,
  - serial/concurrent modes,
  - requests per user.
- Scoped the matrix baseline to a single edge endpoint.
- Added result persistence under:


Each matrix run writes:
```txt
config.json
one JSON file per run
summary.json
Metrics Added
```

**_The evaluator now reports:_**

request latency, throughput, success/error counts, service-reported total time, model inference time, inference-excluded time, component timings from /generate, memory source counts, handover mode counts, cold-request metrics, hot-request metrics. Cold vs Hot Request Tracking

**The baseline now separates requests into:**
cold: the first request from each logical user
hot: later requests from the same logical user.

This allows the evaluation to measure cache utilization more directly. The matrix summary includes:

- coldLatencyMeanMs
- hotLatencyMeanMs
- hotInferenceExcludedMeanMs

_

> Concurrent mode preserves per-user ordering, so a user’s hot request cannot start before that user’s cold request finishes. Different users can still run concurrently.

### Edge Service Metrics

The edge-node /generate response now includes additional timing data:
- handoverDecisionMs
- neighborRecoveryMs
- stmReadMs
- memoryRetrievalMs
- promptBuildMs
- tokenizationMs
- inferenceMs
- inferenceTtftMs
- postInferenceMs
- inferenceExcludedMs

See part of smoke result runned for current model(`Qwen/Qwen2.5-0.5B-Instruct`) and machine (`M1 Pro Chip`):

```txt
- 1 user
- serial mode
- 2/2 successful requests
- cold mean latency: 2289.81ms
- hot mean latency: 1066.36ms
- hot inference-excluded mean: 1.85ms
```

### Follow-Up Work
- Add congestion-specific evaluation scenarios.
- Add multi-edge topology evaluation separately from single-edge baseline.
- Add handover/mobility evaluation.
- Add simulated cloud baseline with configurable RTT.
- Add memory-layer timeout/fallback handling for more stable high-concurrency runs.